### PR TITLE
Do not default to building for Raspberry PI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-target = "armv7-unknown-linux-gnueabihf"


### PR DESCRIPTION
This was handy when doing the initial development, but is less useful when building through Travis CI.