### PR TITLE
README: fixed incorrect example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ pub fn main() {
     loop {
         for y in 0..16 {
             for x in 0..16 {
-                hat_hd.set_pixel(x, y, 255, 255, 255);
+                hat_hd.set_pixel(x, y, [255, 255, 255].into());
                 hat_hd.display().unwrap();
-                hat_hd.set_pixel(x, y, 0, 0, 0);
+                hat_hd.set_pixel(x, y, [0, 0, 0].into());
             }
         }
     }


### PR DESCRIPTION
There probably was an API change, but the example code in the README wasn't updated and doesn't compile anymore.